### PR TITLE
Update license block in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,7 +198,7 @@ Make your own or ask for it on through pull requests or issues !
 | :---: | :---: | :---: | :---: | :---: |
 
 ## License
-Okty is made available under the [MIT License](http://www.opensource.org/licenses/mit-license.php).
+Okty is made available under the [GNU GPL v3 License](https://opensource.org/licenses/GPL-3.0).
 
 ## Credits
 Okty is created and maintained by


### PR DESCRIPTION
I updated the license block in the readme to be the same as https://github.com/Okty-io/okty/blob/master/README.md, as the license is the same ;)